### PR TITLE
Coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "env": {
     "webpack": {
       "plugins": [
+        "istanbul", // TODO: include only when testing
         "transform-decorators-legacy",
         "transform-class-properties"
       ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "4.0.5"
   },
   "scripts": {
-    "pretest": "del-cli \"test/coverage\"",
+    "pretest": "del-cli \"coverage/*\"",
     "test": "cross-env BABEL_ENV=node NODE_ENV=test ./node_modules/karma/bin/karma start test/karma.conf.js",
     "test:debug": "npm test -- --single-run=false --auto-watch=true --debug",
     "test:bs": "cd coverage && browser-sync start --server -f ./**/*.html",
@@ -20,7 +20,7 @@
     "e2e:start-when-ready": "wait-on --timeout 120000 http-get://localhost:19876/index.html && npm run e2e:start",
     "e2e:start": "cross-env ./node_modules/.bin/protractor test/protractor.conf.js",
     "e2e:live": "npm run e2e:start -- --elementExplorer",
-    "clean": "npm cache clean && del-cli node_modules \"test/coverage\" dist",
+    "clean": "npm cache clean && del-cli node_modules \"coverage/*\" dist",
     "clean:dist": "del-cli dist",
     "preclean:install": "npm run clean",
     "clean:install": "npm install",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.0.2",
     "karma-mocha-reporter": "^2.2.0",
-    "karma-remap-istanbul": "^0.2.1",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.8.0",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "aurelia-protractor-plugin": "^1.0.1",
     "aurelia-tools": "^1.0.0",
     "babel-eslint": "^7.1.1",
+    "babel-plugin-istanbul": "^3.1.2",
     "babel-plugin-transform-class-properties": "^6.18.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-env": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "pretest": "del-cli \"test/coverage\"",
     "test": "cross-env BABEL_ENV=node NODE_ENV=test ./node_modules/karma/bin/karma start test/karma.conf.js",
     "test:debug": "npm test -- --single-run=false --auto-watch=true --debug",
-
+    "test:bs": "cd coverage && browser-sync start --server -f ./**/*.html",
     "webdriver:update": "cross-env ./node_modules/.bin/webdriver-manager update",
     "webdriver:start": "cross-env ./node_modules/.bin/webdriver-manager start",
     "pree2e": "npm run webdriver:update -- --standalone",
@@ -39,7 +39,6 @@
     "start": "npm run server:dev",
     "server": "npm run server:dev",
     "server:dev": "cross-env NODE_ENV=development npm run webpack-dev-server -- --inline --progress --profile --watch",
-
     "server:dev:hmr": "npm run server:dev -- --hot",
     "server:prod": "http-server dist --cors",
     "webpack": "cross-env BABEL_ENV=node ./node_modules/.bin/webpack",
@@ -75,7 +74,6 @@
         "aurelia-auth",
         "aurelia-auth/auth-filter",
         "aurelia-environment"
-
       ],
       "includeDependencies": [
         "!http-server"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -40,20 +40,10 @@ module.exports = function(config) {
 
     coverageReporter: {
       reporters: [{
-        type: 'json',
+        type: 'html',
         dir: '../coverage',
-        subdir: '.',
-        file: 'coverage-final.json'
+        subdir: '.'
       }]
-    },
-
-    remapIstanbulReporter: {
-      src: path.join(__dirname, '../coverage/coverage-final.json'),
-      reports: {
-        html: path.join(__dirname, '../coverage/')
-      },
-      timeoutNotCreated: 1000,
-      timeoutNoMoreFiles: 1000
     },
 
     // Webpack please don't spam the console when running in karma!
@@ -65,7 +55,7 @@ module.exports = function(config) {
      * possible values: 'dots', 'progress'
      * available reporters: https://npmjs.org/browse/keyword/karma-reporter
      */
-    reporters: [ 'mocha', 'coverage', 'karma-remap-istanbul' ],
+    reporters: [ 'mocha', 'coverage' ],
 
     // web server port
     port: 9876,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
      * available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
      */
     preprocessors: {
-      'spec-bundle.js': ['coverage', 'webpack', 'sourcemap']
+      'spec-bundle.js': ['webpack', 'sourcemap']
     },
 
     webpack: require('../webpack.config.babel'),


### PR DESCRIPTION
* remove karma-remap-istanbul

  `karma-remap-istanbul` was being used to move coverage from '../coverage' back into source, which is its main purpose, but it was causing issues...

  It was making `test:dev` task re-run indefinitely and irrespective of whether files were modified
beacuse was in a loop monitoring (coverage) files it itself creates or modifies inside source dir.


Was `karma-remap-istanbul` needed? Let me know. And if we could still manage to avoid the above issue

Some other fixes/changes. Please review and let me know. 