### PR TITLE
remove instrumentation from source for karma debugger

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -136,7 +136,7 @@ let config = generateConfig(
     ]})
   ] : [
     /* ENV === 'test' */
-    generateCoverage({ options: { 'force-sourcemap': true, esModules: true }})
+    // generateCoverage({ options: { 'force-sourcemap': true, esModules: true }})
   ]),
 
   // ENV != 'production' ? [


### PR DESCRIPTION
fixes #259

Coverage would still work because karma config has the necessary config for coverage. 