### PR TITLE
remove copy-files webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
         "aurelia-auth/auth-filter",
         "au-table/dist/amd",
         "au-table/dist/amd/au-table-pagination",
-        "aurelia-environment"
       ],
       "includeDependencies": [
         "!http-server",
@@ -107,7 +106,6 @@
         "!aurelia-polymer",
         "!aurelia-protractor-plugin",
         "!aurelia-tools",
-        "!aurelia-environment",
         "!babel-eslint",
         "!babel-plugin-istanbul",
         "!babel-plugin-transform-class-properties",
@@ -140,7 +138,6 @@
     "au-table": "^0.1.12",
     "aurelia-auth": "^3.0.5",
     "aurelia-bootstrapper-webpack": "^1.1.0",
-    "aurelia-environment": "^0.1.7",
     "aurelia-event-aggregator": "^1.0.1",
     "aurelia-fetch-client": "^1.1.0",
     "aurelia-framework": "^1.0.8",

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,6 @@ import 'font-awesome/css/font-awesome.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap';
 import config from '../authConfig';
-import {load} from 'aurelia-environment';
 //var ap = require('aurelia-polymer');
 // comment out if you don't want a Promise polyfill (remove also from webpack.common.js)
 
@@ -13,25 +12,23 @@ Bluebird.config({ warnings: false });
 
 export async function configure(aurelia) {
   if (process.env.NODE_ENV !== 'production'){
-    load({file: '.env'}).then(() => {
-      aurelia.use
+    aurelia.use
       .standardConfiguration()
       .developmentLogging();
-      aurelia.use.plugin('aurelia-polymer');
-      aurelia.use.plugin('aurelia-auth', (baseConfig)=>{
-        baseConfig.configure(config);
-      });
-      aurelia.use.plugin('au-table');
+    aurelia.use.plugin('aurelia-polymer');
+    aurelia.use.plugin('aurelia-auth', (baseConfig)=>{
+      baseConfig.configure(config);
+    });
+    aurelia.use.plugin('au-table');
       //aurelia.use.plugin('aurelia-files');
       // Uncomment the line below to enable animation.
       // aurelia.use.plugin('aurelia-animator-css');
       // if the css animator is enabled, add swap-order="after" to all router-view elements
       // Anyone wanting to use HTMLImports to load views, will need to install the following plugin.
       // aurelia.use.plugin('aurelia-html-import-template-loader')
-      aurelia.start().then(() => aurelia.setRoot('app'));
+    aurelia.start().then(() => aurelia.setRoot('app'));
       //await aurelia.start();
       //aurelia.setRoot('app');
-    });
   } else {
     aurelia.use
     .standardConfiguration()

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -44,8 +44,7 @@ const coreBundles = {
     'bluebird',
     'aurelia-polymer',
     'aurelia-auth',
-    'au-table',
-    'aurelia-environment'
+    'au-table'
   ],
   // these will be included in the 'aurelia' bundle (except for the above bootstrap packages)
   aurelia: [
@@ -74,8 +73,7 @@ const coreBundles = {
     'aurelia-templating-resources',
     'aurelia-polymer',
     'aurelia-auth',
-    'au-table',
-    'aurelia-environment'
+    'au-table'
     // 'aurelia-files'
   ]
 };
@@ -136,7 +134,7 @@ let config = generateConfig(
     ]})
   ] : [
     /* ENV === 'test' */
-    generateCoverage({ options: { 'force-sourcemap': true, esModules: true }})
+    // generateCoverage({ options: { 'force-sourcemap': true, esModules: true }})
   ]),
 
   // ENV != 'production' ? [

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -119,7 +119,7 @@ let config = generateConfig(
   globalJquery(),
   globalRegenerator(),
   generateIndexHtml({minify: ENV === 'production'}),
-  copyFiles({patterns: [{ from: '.env', to: './'}]}),
+  // copyFiles({patterns: [{ from: '.env', to: './'}]}),
   {
     plugins: [
       new webpack.ProvidePlugin({


### PR DESCRIPTION
fixes #266

I think this `copy-wepback-plugin` (which is causing the error in #266, because it's trying to copy `.env` file, in order to make it available for `aurelia-environment`) is not needed anymore. 

It used to be `aurelia.env` before. The `aurelia-environment`, as I highlited in #199, makes them available as `window.env.xxx`, **but** only after a `load().then(...)` ([docs](https://github.com/MarcScheib/aurelia-environment/blob/master/doc/Usage.md)) so it can't be used in top-level definitions, and why it was also not working in many cases (were fixed in #199 at least). 

I also proposed that we just use `webpack.EnvironmentPlugin` to load env variables in `process.env`

I haven't looked at recent code or commits but if that's direction that we've gone then `copy-wepback-plugin` isn't needed and removing it will resolve the error.