### PR TITLE
Fix/261b

### DIFF
--- a/src/dashboard-routes/bookstore-routes/createBooks.js
+++ b/src/dashboard-routes/bookstore-routes/createBooks.js
@@ -2,11 +2,12 @@ import {inject} from 'aurelia-framework';
 import {HttpClient, json} from 'aurelia-fetch-client';
 import {Router} from 'aurelia-router';
 
-@inject(HttpClient, Router)
+@inject(HttpClient, Router, FileReader)
 export class CreateBookDashboard {
-  constructor(httpClient, router){
+  constructor(httpClient, router, reader){
     this.httpClient = httpClient;
     this.router = router;
+    this.reader = reader;
     this.newBook = {
       'title': '',
       'type': 'book',
@@ -24,14 +25,14 @@ export class CreateBookDashboard {
   newBook = null;
   CSVFilePath = {files: ['']};
   fileList = '';
-  
+
   createBook(){
     if (this.newBook.type !== 0){
       this.newBook.type = this.types[this.newBook.type - 1];
     } else {
       this.newBook.type = 'book';
     }
-    
+
     this.httpClient.fetch(process.env.BackendUrl + '/book/', {
       method: 'post',
       body: json(this.newBook)
@@ -42,7 +43,7 @@ export class CreateBookDashboard {
       this.router.navigate('/bookshelf');
     });
   }
-  
+
   createBooksFromCSV(){
     let jsonObj;
     const httpClient = this.httpClient;
@@ -71,10 +72,9 @@ export class CreateBookDashboard {
     if (CSVFilePath.files[0] !== ''){
       // TODO: Parse all csv files
       // TODO: add check for browser support of FileReader
-      let reader = new FileReader();
-      reader.readAsText(CSVFilePath.files[0]);
-      reader.onload = loaded;
-      reader.onerror = errorHandler;
+      this.reader.onload = loaded;
+      this.reader.onerror = errorHandler;
+      this.reader.readAsText(CSVFilePath.files[0]);
     }
   }
 }

--- a/test/unit/createBooks.spec.fixtures.js
+++ b/test/unit/createBooks.spec.fixtures.js
@@ -1,8 +1,12 @@
+import csvjson from 'csvjson';
 
-const csvFixture = {
-    string : `title,type,author,numberPages,dateOfPub,url,isbn,siteLocation,numberOfCopies,comments
+const csvString = `title,type,author,numberPages,dateOfPub,url,isbn,siteLocation,numberOfCopies,comments
 title1,type1,author1,numberPages1,dateOfPub1,url1,isbn1,siteLocation1,numberOfCopies1,comments1
-title2,type2,author2,numberPages2,dateOfPub2,url2,isbn2,siteLocation2,numberOfCopies2,comments2`
-};
+title2,type2,author2,numberPages2,dateOfPub2,url2,isbn2,siteLocation2,numberOfCopies2,comments2`;
 
-export default csvFixture
+const csvJson = csvjson.toObject(csvString);
+
+export const csvFixture = {
+  string: csvString,
+  json: csvJson
+};


### PR DESCRIPTION
fixes #261

In my earlier commit I mistakenly "fixed" a global variable `CSVFilePath`

The `<input id="CSVFilePath" …>` (in `createBooks.html`) makes its contents available (apparently) in a global variable `CSVFilePath`. I mistakenly thought it was a typo and changed it to `this.CSVFilePath` which is what broke it from functioning in the browser (it did pass the tests though).

Sorry about that. That was the only breaking piece of code. I've tested the functionality in browser and it correctly consumes the csv file and displays the resulting book structure.

Also reinstated the test which was removed due to the above. 