### PR TITLE
allow dev-env config for non-localhost domains

### DIFF
--- a/authConfig.js
+++ b/authConfig.js
@@ -72,7 +72,11 @@ var configForProduction = {
     loginRedirect: '#/dashboard',
 };
 var config ;
-if (window.location.hostname==='localhost') {
+if (
+  window.location.hostname === 'localhost'
+  || process.env.NODE_ENV
+  && process.env.NODE_ENV.match(/dev/i)
+) {
     config = configForDevelopment;
 }
 else{


### PR DESCRIPTION
I use [hotel](https://github.com/typicode/hotel) that lets you proxy `http://localhost:8000` to `http://project.dev`, so this allows having `configForDevelopment` depend on `NODE_ENV` as well. 